### PR TITLE
Remove ramp parameters sorting

### DIFF
--- a/src/appleseedmaya/exporters/rampexporter.cpp
+++ b/src/appleseedmaya/exporters/rampexporter.cpp
@@ -110,8 +110,6 @@ void RampExporter::exportParameterValue(
             rampColors.push_back(RampEntry(p, c));
         }
 
-        std::sort(rampColors.begin(), rampColors.end());
-
         std::stringstream ssp;
         ssp << "float[] ";
 


### PR DESCRIPTION
Maya sorts the ramp positions, colors, not by ramp order but by the
order in which you create these elements. Sorting these globally though
would break some ramp cases, such as the four corner ramp, so this needs to be
disabled, and the component access is dealt with in the shader code.