### PR TITLE
Fix compilation and clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ set (appleseed_maya_version_patch    0)
 # Build options.
 #--------------------------------------------------------------------------------------------------
 
-option (USE_STATIC_BOOST    "Use static Boost libraries" OFF)
+option (USE_STATIC_BOOST    "Use static Boost libraries" ON)
 option (WITH_PYTHON_BRIDGE  "Build Python bridge"        OFF)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if (USE_STATIC_BOOST)
     set (Boost_USE_STATIC_LIBS TRUE)
 endif ()
 
-set (BOOST_NEEDED_LIBS system filesystem)
+set (BOOST_NEEDED_LIBS filesystem system)
 
 if (WITH_PYTHON_BRIDGE)
     set (BOOST_NEEDED_LIBS ${BOOST_NEEDED_LIBS} python)
@@ -108,7 +108,20 @@ endif ()
 find_package (Boost 1.55 REQUIRED ${BOOST_NEEDED_LIBS})
 
 add_definitions (-DBOOST_FILESYSTEM_VERSION=3 -DBOOST_FILESYSTEM_NO_DEPRECATED)
-add_definitions (-DBOOST_ALL_NO_LIB)
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Link statically against Boost.Python on Windows.
+    add_definitions (-DBOOST_PYTHON_STATIC_LIB)
+endif ()
+
+if (NOT CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    # Workaround for undefined reference to boost::filesystem::detail::copy_file link error
+    # on Linux and macOS if Boost is built in C++03 mode.
+    add_definitions (-DBOOST_NO_CXX11_SCOPED_ENUMS)
+endif ()
+
+include_directories (SYSTEM ${Boost_INCLUDE_DIRS})
+link_directories (${Boost_LIBRARY_DIRS})
 
 
 #--------------------------------------------------------------------------------------------------
@@ -143,7 +156,6 @@ include_directories (
     ${OPENIMAGEIO_INCLUDE_DIRS}
     ${OSL_INCLUDE_DIRS}
     ${PYTHON_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 

--- a/scripts/appleseedMaya/xgenseedutil.py
+++ b/scripts/appleseedMaya/xgenseedutil.py
@@ -33,7 +33,7 @@ import types
 def castSelf(selfid):
     # Can't pass self as an object.
     # It's cast to id(self) by the caller
-    # and we convert it back to a python object here
+    # and we convert it back to a Python object here
     if isinstance(selfid,str):
         return ctypes.cast(int(selfid), ctypes.py_object).value
     else:

--- a/src/appleseedmaya/CMakeLists.txt
+++ b/src/appleseedmaya/CMakeLists.txt
@@ -89,8 +89,8 @@ set (appleseed_maya_sources
 if (WITH_PYTHON_BRIDGE)
     set (appleseed_maya_sources
         ${appleseed_maya_sources}
-        python.cpp
-        python.h
+        pythonbridge.cpp
+        pythonbridge.h
     )
 endif ()
 source_group ("" FILES

--- a/src/appleseedmaya/pluginmain.cpp
+++ b/src/appleseedmaya/pluginmain.cpp
@@ -37,7 +37,7 @@
 #include "appleseedmaya/idlejobqueue.h"
 #include "appleseedmaya/logger.h"
 #ifdef APPLESEED_MAYA_WITH_PYTHON_BRIDGE
-#include "appleseedmaya/python.h"
+#include "appleseedmaya/pythonbridge.h"
 #endif
 #include "appleseedmaya/rendercommands.h"
 #include "appleseedmaya/renderglobalsnode.h"

--- a/src/appleseedmaya/pluginmain.cpp
+++ b/src/appleseedmaya/pluginmain.cpp
@@ -179,12 +179,12 @@ APPLESEED_MAYA_PLUGIN_EXPORT MStatus initializePlugin(MObject plugin)
     status = MGlobal::executePythonCommand("import appleseed", false, false);
     APPLESEED_MAYA_CHECK_MSTATUS_RET_MSG_LOG(
         status,
-        "appleseedMaya: failed to import required python modules");
+        "appleseedMaya: failed to import required Python modules");
 
     status = MGlobal::executePythonCommand("import appleseedMaya", false, false);
     APPLESEED_MAYA_CHECK_MSTATUS_RET_MSG_LOG(
         status,
-        "appleseedMaya: failed to import required python modules");
+        "appleseedMaya: failed to import required Python modules");
 
     status = MGlobal::executePythonCommand("import appleseedMaya.register; appleseedMaya.register.register()", false, false);
     APPLESEED_MAYA_CHECK_MSTATUS_RET_MSG_LOG(
@@ -250,7 +250,7 @@ APPLESEED_MAYA_PLUGIN_EXPORT MStatus initializePlugin(MObject plugin)
     status = PythonBridge::initialize(pluginPath);
     APPLESEED_MAYA_CHECK_MSTATUS_RET_MSG_LOG(
         status,
-        "appleseedMaya: failed to initialize python bridge");
+        "appleseedMaya: failed to initialize Python bridge");
 #endif
 
     IdleJobQueue::initialize();
@@ -291,7 +291,7 @@ APPLESEED_MAYA_PLUGIN_EXPORT MStatus uninitializePlugin(MObject plugin)
     status = PythonBridge::uninitialize();
     APPLESEED_MAYA_CHECK_MSTATUS_RET_MSG_LOG(
         status,
-        "appleseedMaya: failed to unititialize python bridge");
+        "appleseedMaya: failed to unititialize Python bridge");
 #endif
 
     status = NodeExporterFactory::uninitialize();

--- a/src/appleseedmaya/pythonbridge.cpp
+++ b/src/appleseedmaya/pythonbridge.cpp
@@ -26,17 +26,17 @@
 // THE SOFTWARE.
 //
 
-// Python headers.
-#include <Python.h>
-
 // Interface header.
-#include "appleseedmaya/python.h"
-
-// Boost headers.
-#include "boost/python.hpp"
+#include "appleseedmaya/pythonbridge.h"
 
 // appleseed.renderer headers.
 #include "renderer/api/project.h"
+
+// appleseed.foundation headers.
+#include "foundation/platform/python.h"
+
+// Boost headers.
+#include "boost/python.hpp"
 
 namespace bpy = boost::python;
 namespace asf = foundation;

--- a/src/appleseedmaya/pythonbridge.cpp
+++ b/src/appleseedmaya/pythonbridge.cpp
@@ -35,34 +35,29 @@
 // appleseed.foundation headers.
 #include "foundation/platform/python.h"
 
-// Boost headers.
-#include "boost/python.hpp"
-
 namespace bpy = boost::python;
 namespace asf = foundation;
 namespace asr = renderer;
 
 namespace
 {
-
-struct ScopedGilState
-{
-    ScopedGilState()
+    struct ScopedGilState
     {
-        state = PyGILState_Ensure();
-    }
+        PyGILState_STATE state;
 
-    ~ScopedGilState()
-    {
-        PyGILState_Release(state);
-    }
+        ScopedGilState()
+        {
+            state = PyGILState_Ensure();
+        }
 
-    PyGILState_STATE state;
-};
+        ~ScopedGilState()
+        {
+            PyGILState_Release(state);
+        }
+    };
 
-bpy::object gAppleseedMayaNamespace;
-
-} // unnamed
+    bpy::object gAppleseedMayaNamespace;
+}
 
 MStatus PythonBridge::initialize(const MString& pluginPath)
 {
@@ -93,7 +88,7 @@ MStatus PythonBridge::uninitialize()
     return status;
 }
 
-void PythonBridge::setCurrentProject(renderer::Project *project)
+void PythonBridge::setCurrentProject(renderer::Project* project)
 {
     ScopedGilState gilState;
     gAppleseedMayaNamespace["currentProject"] = bpy::ptr(project);

--- a/src/appleseedmaya/pythonbridge.h
+++ b/src/appleseedmaya/pythonbridge.h
@@ -26,8 +26,8 @@
 // THE SOFTWARE.
 //
 
-#ifndef APPLESEED_MAYA_PYTHON_H
-#define APPLESEED_MAYA_PYTHON_H
+#ifndef APPLESEED_MAYA_PYTHONBRIDGE_H
+#define APPLESEED_MAYA_PYTHONBRIDGE_H
 
 // Maya headers.
 #include <maya/MStatus.h>
@@ -36,19 +36,21 @@
 // appleseed.maya headers.
 #include "appleseedmaya/utils.h"
 
+// appleseed.foundation headers.
+#include "foundation/core/concepts/noncopyable.h"
+
 // Forward declarations.
 namespace renderer { class Project; }
 
 class PythonBridge
-  : NonCopyable
+  : public foundation::NonCopyable
 {
   public:
-
     static MStatus initialize(const MString& pluginPath);
     static MStatus uninitialize();
 
-    static void setCurrentProject(renderer::Project *project);
+    static void setCurrentProject(renderer::Project* project);
     static void clearCurrentProject();
 };
 
-#endif  // !APPLESEED_MAYA_PYTHON_H
+#endif  // !APPLESEED_MAYA_PYTHONBRIDGE_H


### PR DESCRIPTION
This fixes issue #59, among other things.

For the sake of consistency with appleseed, we now also default to static Boost libraries. You may need to set `USE_STATIC_BOOST` back to `OFF` on your Linux/macOS setups.