### PR TITLE
Add partial path for object name queries

### DIFF
--- a/src/appleseedmaya/appleseedsession.cpp
+++ b/src/appleseedmaya/appleseedsession.cpp
@@ -428,7 +428,6 @@ namespace
                     RENDERER_LOG_DEBUG(
                         "Setting active camera to %s",
                         camera.fullPathName().asChar());
-
                     params.insert("camera", camera.partialPathName().asChar());
                 }
                 else

--- a/src/appleseedmaya/appleseedsession.cpp
+++ b/src/appleseedmaya/appleseedsession.cpp
@@ -428,7 +428,8 @@ namespace
                     RENDERER_LOG_DEBUG(
                         "Setting active camera to %s",
                         camera.fullPathName().asChar());
-                    params.insert("camera", camera.fullPathName().asChar());
+                    //params.insert("camera", camera.fullPathName().asChar());
+                    params.insert("camera", camera.partialPathName().asChar());
                 }
                 else
                     RENDERER_LOG_WARNING("Wrong camera!");

--- a/src/appleseedmaya/appleseedsession.cpp
+++ b/src/appleseedmaya/appleseedsession.cpp
@@ -428,7 +428,7 @@ namespace
                     RENDERER_LOG_DEBUG(
                         "Setting active camera to %s",
                         camera.fullPathName().asChar());
-                    //params.insert("camera", camera.fullPathName().asChar());
+
                     params.insert("camera", camera.partialPathName().asChar());
                 }
                 else

--- a/src/appleseedmaya/exporters/dagnodeexporter.cpp
+++ b/src/appleseedmaya/exporters/dagnodeexporter.cpp
@@ -115,7 +115,8 @@ void DagNodeExporter::exportShapeMotionStep(float time)
 
 MString DagNodeExporter::appleseedName() const
 {
-    return dagPath().fullPathName();
+   // return dagPath().fullPathName();
+    return dagPath().partialPathName();
 }
 
 const MDagPath& DagNodeExporter::dagPath() const

--- a/src/appleseedmaya/exporters/dagnodeexporter.cpp
+++ b/src/appleseedmaya/exporters/dagnodeexporter.cpp
@@ -115,7 +115,6 @@ void DagNodeExporter::exportShapeMotionStep(float time)
 
 MString DagNodeExporter::appleseedName() const
 {
-   // return dagPath().fullPathName();
     return dagPath().partialPathName();
 }
 


### PR DESCRIPTION
Together with https://github.com/appleseedhq/appleseed/pull/1566 allows one to query *object:object_name* and *object:object_instance_name* from OSL via **getattribute()**, and is one of the requirements for the N-switch nodes.