### PR TITLE
Fix RTD builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
+# Sphinx 1.7.1 fails with sphinxcontrib-images, force 1.6.7
+sphinx==1.6.7
+
 # Sphinx-bootstrap-theme
 sphinx-bootstrap-theme
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 from sphinx.util import compat
 compat.make_admonition = BaseAdmonition
 
-needs_sphinx = '1.6'
+needs_sphinx = '1.6.7'
 
 # For automagical GIT versioning (describe, tags)
 #


### PR DESCRIPTION
The documentation builds were failing since Sphinx 1.7.1 introduced an incompatibility with sphinxcontrib-images, which we need for the thumbnails. So we set the requirements for a working version (1.6.7). If the need arises to use 1.7+, this must be revisited.