### PR TITLE
Add new IDs, node help, bump UI fixes

### DIFF
--- a/scripts/appleseedMaya/AEappleseedBumpControl.mel
+++ b/scripts/appleseedMaya/AEappleseedBumpControl.mel
@@ -1,0 +1,30 @@
+
+//
+// Based on the standard MEL included with Lambert, but allowing a specific
+// label - needed if you want to have separate bump controls for diffuse,
+// specular, or coating and substrate for instance.
+//
+
+global proc AEappleseedShaderBumpNew(string $attrName)
+{
+    setUITemplate -pst attributeEditorTemplate;
+
+    string $tokens[];
+    tokenize $attrName "." $tokens;
+
+    $niceName = `attributeQuery -node $tokens[0] -niceName $tokens[1]`;
+    
+    attrNavigationControlGrp
+        -label $niceName
+        -at $attrName
+        bumpControl;
+
+    setUITemplate -ppt;
+}
+
+global proc AEappleseedShaderBumpReplace(string $attrName)
+{
+    attrNavigationControlGrp -edit
+        -at $attrName
+        bumpControl;
+}

--- a/src/appleseedmaya/shadingnodemetadata.cpp
+++ b/src/appleseedmaya/shadingnodemetadata.cpp
@@ -199,6 +199,7 @@ std::ostream& operator<<(std::ostream& os, const OSLParamInfo& paramInfo)
     os << "Param : " << paramInfo.paramName << "\n";
     os << "  maya name      : " << paramInfo.mayaAttributeName << "\n";
     os << "  type           : " << paramInfo.paramType << "\n";
+    os << "  widget         : " << paramInfo.widget << "\n";
     os << "  output         : " << paramInfo.isOutput << "\n";
     os << "  valid default  : " << paramInfo.validDefault << "\n";
     os << "  closure        : " << paramInfo.isClosure << "\n";
@@ -231,6 +232,7 @@ OSLShaderInfo::OSLShaderInfo(
     metadata.getValue("as_maya_node_name", mayaName);
     metadata.getValue("as_maya_classification", mayaClassification);
     metadata.getValue<unsigned int>("as_maya_type_id", typeId);
+    metadata.getValue("URL", shaderHelpURL);
 
     paramInfo.reserve(q.get_param_count());
     for (size_t i = 0, e = q.get_param_count(); i < e; ++i)

--- a/src/appleseedmaya/shadingnodemetadata.h
+++ b/src/appleseedmaya/shadingnodemetadata.h
@@ -160,6 +160,7 @@ class OSLShaderInfo
     MString shaderName;
     MString shaderType;
     MString shaderFileName;
+    MString shaderHelpURL;
 
     // Maya related info.
     MString mayaName;

--- a/src/appleseedmaya/shadingnoderegistry.cpp
+++ b/src/appleseedmaya/shadingnoderegistry.cpp
@@ -79,6 +79,7 @@ namespace
         std::cout << "  Name = " << p.paramName << " type = " << p.paramType << "\n";
         std::cout << "    Maya Attribute = " << p.mayaAttributeName << "\n";
         std::cout << "    IsOutput = " << p.isOutput << "\n";
+        std::cout << "    Widget = " << p.widget << "\n";
         std::cout << "    IsClosure = " << p.isClosure << "\n";
 
         if (p.isArray)
@@ -98,6 +99,7 @@ namespace
         std::cout << "File Name = " << s.shaderFileName << "\n";
         std::cout << "Maya Name = " << s.mayaName << "\n";
         std::cout << "Maya Classification = " << s.mayaClassification << "\n";
+        std::cout << "Shader help URL = " << s.shaderHelpURL << "\n";
 
         if (s.typeId)
             std::cout << "Maya TypeId = " << s.typeId << "\n";

--- a/src/appleseedmaya/shadingnodetemplatebuilder.cpp
+++ b/src/appleseedmaya/shadingnodetemplatebuilder.cpp
@@ -88,6 +88,7 @@ class LayoutTree
 
         // Import the bump control.
         ss << "source AElambertCommon;\n";
+        ss << "source AEappleseedBumpControl;\n";
 
         // Create the AE procedure.
         ss << "global proc AE" << shaderInfo.mayaName << "Template(string $nodeName)\n";
@@ -106,6 +107,11 @@ class LayoutTree
             if (p.widget == "null")
                 ss << "    editorTemplate -suppress \"" << p.mayaAttributeName << "\";\n";
         }
+
+        // Add help
+        ss << "addAttributeEditorNodeHelp(\"" << shaderInfo.mayaName
+           << "\", " << "\"showHelp -absolute \\\"" << shaderInfo.shaderHelpURL
+           << "\\\"\");\n;";
 
         // Include/call base class/node attributes.
         ss << "    AEdependNodeTemplate $nodeName;\n";
@@ -178,11 +184,9 @@ private:
             {
                 indent(ss, level);
 
-                // Special case for Maya's bump. We want to reuse the bump control.
-                // Maybe this should be specified by some metadata entry instead of
-                // by attribute name?
-                if (m_paramInfo->mayaAttributeName == "normalCamera")
-                    ss << "editorTemplate -callCustom \"AEshaderBumpNew\" \"AEshaderBumpReplace\" \"normalCamera\";\n";
+                if (m_paramInfo->widget == "maya_bump" || m_paramInfo->mayaAttributeName == "normalCamera")
+                    ss << "editorTemplate -callCustom \"AEappleseedShaderBumpNew\" \"AEappleseedShaderBumpReplace\" \""
+                       << m_paramInfo->mayaAttributeName << "\";\n";
                 else if (m_paramInfo->asWidget == "ramp")
                     ss << "AEaddRampControl($nodeName + \"." << m_paramInfo->mayaAttributeName << "\");\n";
                 else if (m_paramInfo->asWidget == "ramp_positions")

--- a/src/appleseedmaya/typeids.h
+++ b/src/appleseedmaya/typeids.h
@@ -105,6 +105,8 @@ enum AppleseedMayaTypeIds
     AsBumpNodeTypeId                = 0x00127a00,   // 1210880
     AsToonNodeTypeID                = 0x00127a01,   // 1210881
     AsXToonNodeTypeID               = 0x00127a02,   // 1210882
+    AsFabricNodeTypeID              = 0x00127a03,   // 1210883
+    AsSbsPbrMaterialNodeTypeID      = 0x00127a04,   // 1210884
 
     LastTypeId                      = 0x00127a3f    // 1210943
 };


### PR DESCRIPTION
The bump control automagically allows the connection of a bump2d, but it
inherits this from the common section of the Maya's Lambert node and
doesn't allow split bump controls. Adding a new procedure we can now
have different bump for different layers, i.e, coating, substrate.
The plugin was not parsing standard OSL URL metadata token, and as a
result, the default node help was launching the autodesk page and trying
to find our node's documentation there. Adding this allows the user to
go direct from maya attribute editor to the appleseed read-the-docs
documentation.
Finally, new IDs added for the Substance PBR material and the Fabric
material (closure WIP).