### PR TITLE
Update cmake build scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # This software is released under the MIT license.
 #
-# Copyright (c) 2016-2018 Esteban Tovagliari, The appleseedhq Organization
+# Copyright (c) 2016-2019 Esteban Tovagliari, The appleseedhq Organization
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@
 # CMake configuration.
 #--------------------------------------------------------------------------------------------------
 
-cmake_minimum_required (VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.9 FATAL_ERROR)
 
 
 #--------------------------------------------------------------------------------------------------
@@ -110,7 +110,7 @@ endif ()
 
 set (BOOST_NEEDED_LIBS filesystem system)
 
-find_package (Boost 1.55 REQUIRED ${BOOST_NEEDED_LIBS})
+find_package (Boost 1.61 REQUIRED ${BOOST_NEEDED_LIBS})
 
 add_definitions (-DBOOST_FILESYSTEM_VERSION=3 -DBOOST_FILESYSTEM_NO_DEPRECATED)
 

--- a/cmake/Modules/FindAppleseed.cmake
+++ b/cmake/Modules/FindAppleseed.cmake
@@ -1,4 +1,29 @@
-# Copyright (c) 2013 Esteban Tovagliari
+#
+# This source file is part of appleseed.
+# Visit https://appleseedhq.net/ for additional information and resources.
+#
+# This software is released under the MIT license.
+#
+# Copyright (c) 2013-2019 Esteban Tovagliari, The appleseedhq Organization
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
 
 # Find appleseed's headers and libraries.
 #

--- a/cmake/Modules/FindImath.cmake
+++ b/cmake/Modules/FindImath.cmake
@@ -5,7 +5,7 @@
 #
 # This software is released under the MIT license.
 #
-# Copyright (c) 2013-2018 Esteban Tovagliari, The appleseedhq Organization
+# Copyright (c) 2013-2019 Esteban Tovagliari, The appleseedhq Organization
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/cmake/Modules/FindMaya.cmake
+++ b/cmake/Modules/FindMaya.cmake
@@ -1,4 +1,3 @@
-
 # - Maya finder module
 # This module searches for a valid Maya instalation.
 # It searches for Maya's devkit, libraries, executables
@@ -10,9 +9,9 @@
 # MAYA_<lib>_FOUND    Defined if <lib> has been found
 # MAYA_<lib>_LIBRARY  Path to <lib> library
 # MAYA_INCLUDE_DIRS   Path to the devkit's include directories
-# MAYA_API_VERSION    Maya API version
+# MAYA_API_VERSION    Maya version (6-8 digits)
 #
-# IMPORTANT: Currently, there's only support for OSX platform and Maya version 2012.
+# IMPORTANT: Currently, there's only support for OSX platform and Maya version 2017 because of ABI issues with libc++.
 
 #=============================================================================
 # Copyright 2011-2012 Francisco Requena <frarees@gmail.com>
@@ -27,132 +26,192 @@
 # (To distribute this file outside of CMake, substitute the full
 #  License text for the above reference.)
 
-## add one to this list to match your install if none match
-
 if(APPLE)
-  find_path(MAYA_BASE_DIR ../../devkit/include/maya/MFn.h PATH
-    ENV MAYA_LOCATION
-    "/Applications/Autodesk/maya2017/Maya.app/Contents"
-    "/Applications/Autodesk/maya2018/Maya.app/Contents"
-  )
-  find_path(MAYA_LIBRARY_DIR libOpenMaya.dylib
-    PATHS
-      ENV MAYA_LOCATION
-      ${MAYA_BASE_DIR}
-    PATH_SUFFIXES
-      Maya.app/Contents/MacOS/
-    DOC "Maya's libraries path"
-  )
-endif(APPLE)
+    find_path(MAYA_BASE_DIR
+            include/maya/MFn.h
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "/Applications/Autodesk/maya2019"
+            "/Applications/Autodesk/maya2018"
+            "/Applications/Autodesk/maya2017"
+        DOC
+            "Maya installation root directory"
+    )
+    find_path(MAYA_LIBRARY_DIR
+            libOpenMaya.dylib
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "${MAYA_BASE_DIR}"
+        PATH_SUFFIXES
+            Maya.app/Contents/MacOS/
+        DOC
+            "Maya's libraries path"
+    )
+elseif(UNIX)
+    find_path(MAYA_BASE_DIR
+            include/maya/MFn.h
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "/usr/autodesk/maya2019"
+            "/usr/autodesk/maya2018"
+            "/usr/autodesk/maya2017"
+        DOC
+            "Maya installation root directory"
+    )
+    find_path(MAYA_LIBRARY_DIR
+            libOpenMaya.so
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "${MAYA_BASE_DIR}"
+        PATH_SUFFIXES
+            lib/
+        DOC
+            "Maya's libraries path"
+    )
+elseif(WIN32)
+    find_path(MAYA_BASE_DIR
+            include/maya/MFn.h
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "C:/Program Files/Autodesk/Maya2019"
+            "C:/Program Files/Autodesk/Maya2018"
+        DOC
+            "Maya installation root directory"
+    )
+    find_path(MAYA_LIBRARY_DIR
+            OpenMaya.lib
+        HINTS
+            "${MAYA_LOCATION}"
+            "$ENV{MAYA_LOCATION}"
+            "${MAYA_BASE_DIR}"
+        PATH_SUFFIXES
+            lib/
+        DOC
+            "Maya's libraries path"
+    )
+endif()
 
-if(UNIX)
-  find_path(MAYA_BASE_DIR include/maya/MFn.h
-    PATH
-      ENV MAYA_LOCATION
-      "/usr/autodesk/maya2017"
-      "/usr/autodesk/maya2018"
-  )
-  find_path(MAYA_LIBRARY_DIR libOpenMaya.so
-    PATHS
-      ENV MAYA_LOCATION
-      ${MAYA_BASE_DIR}
+find_path(MAYA_INCLUDE_DIR
+        maya/MFn.h
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
     PATH_SUFFIXES
-      lib/
-    DOC "Maya's libraries path"
-  )
-endif(UNIX)
-
-if(WIN32)
-  find_path(MAYA_BASE_DIR include/maya/MFn.h
-    PATH
-      ENV MAYA_LOCATION
-        "C:/Program Files/Autodesk/Maya2017"
-        "C:/Program Files/Autodesk/Maya2018"
-  )
-  find_path(MAYA_LIBRARY_DIR OpenMaya.lib
-    PATHS
-      ENV MAYA_LOCATION
-      ${MAYA_BASE_DIR}
-    PATH_SUFFIXES
-      lib/
-    DOC "Maya's libraries path"
-  )
-endif(WIN32)
-
-find_path(MAYA_INCLUDE_DIR maya/MFn.h
-  HINTS ${MAYA_BASE_DIR}
-  PATHS
-    ENV MAYA_LOCATION
-    ${MAYA_BASE_DIR}
-  PATH_SUFFIXES
-    ../../devkit/include/
-    include/
-  DOC "Maya's devkit headers path"
+        ../../devkit/include/
+        include/
+    DOC
+        "Maya's headers path"
 )
 
-find_path(MAYA_LIBRARY_DIR OpenMaya
-  HINTS ${MAYA_BASE_DIR}
-  PATHS
-    ENV MAYA_LOCATION
-    ${MAYA_BASE_DIR}
-  PATH_SUFFIXES
-    ../../devkit/include/
-    include/
-  DOC "Maya's devkit headers path"
+find_path(MAYA_LIBRARY_DIR
+        OpenMaya
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
+    PATH_SUFFIXES
+        ../../devkit/include/
+        include/
+    DOC
+        "Maya's libraries path"
 )
 
 list(APPEND MAYA_INCLUDE_DIRS ${MAYA_INCLUDE_DIR})
 
-find_path(MAYA_DEVKIT_INC_DIR GL/glext.h
-  HINTS ${MAYA_BASE_DIR}
-  PATHS
-    ENV_MAYA_LOCATION
-    ${MAYA_BASE_DIR}
-  PATH_SUFFIXES
-    ../../devkit/plug-ins/
-    devkit/plug-ins
-  DOC "Maya's devkit headers path"
+find_path(MAYA_DEVKIT_INC_DIR
+       GL/glext.h
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
+    PATH_SUFFIXES
+        ../../devkit/plug-ins/
+    DOC
+        "Maya's devkit headers path"
 )
-
-list(APPEND MAYA_INCLUDE_DIRS ${MAYA_DEVKIT_INC_DIR})
+if(NOT "${MAYA_DEVKIT_INC_DIR}" STREQUAL "MAYA_DEVKIT_INC_DIR-NOTFOUND")
+    list(APPEND MAYA_INCLUDE_DIRS ${MAYA_DEVKIT_INC_DIR})
+endif()
 
 foreach(MAYA_LIB
-  OpenMaya
-  OpenMayaAnim
-  OpenMayaFX
-  OpenMayaRender
-  OpenMayaUI
-  Image
-  Foundation
-  IMFbase
-  tbb
-  Cg
-  CgGL
-)
-  find_library(MAYA_${MAYA_LIB}_LIBRARY ${MAYA_LIB}
-    HINTS ${MAYA_BASE_DIR}
-    PATHS
-      ENV MAYA_LOCATION
-      ${MAYA_BASE_DIR}
-    PATH_SUFFIXES
-      MacOS/
-      lib/
-    DOC "Maya's ${MAYA_LIB} library path"
-  )
+    OpenMaya
+    OpenMayaAnim
+    OpenMayaFX
+    OpenMayaRender
+    OpenMayaUI
+    Image
+    Foundation
+    IMFbase
+    tbb
+    cg
+    cgGL)
 
-  list(APPEND ${MAYA_LIBRARIES} MAYA_${MAYA_LIB}_LIBRARY)
+    find_library(MAYA_${MAYA_LIB}_LIBRARY
+            ${MAYA_LIB}
+        HINTS
+            "${MAYA_LIBRARY_DIR}"
+        DOC
+            "Maya's ${MAYA_LIB} library path"
+        # NO_CMAKE_SYSTEM_PATH needed to avoid conflicts between
+        # Maya's Foundation library and OSX's framework.
+        NO_CMAKE_SYSTEM_PATH
+    )
+
+
+    if (MAYA_${MAYA_LIB}_LIBRARY)
+        list(APPEND MAYA_LIBRARIES ${MAYA_${MAYA_LIB}_LIBRARY})
+    endif()
 endforeach(MAYA_LIB)
 
+find_program(MAYA_EXECUTABLE
+        maya
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
+    PATH_SUFFIXES
+        Maya.app/Contents/bin/
+        bin/
+    DOC
+        "Maya's executable path"
+)
+
+find_program(MAYA_PY_EXECUTABLE
+        mayapy
+    HINTS
+        "${MAYA_LOCATION}"
+        "$ENV{MAYA_LOCATION}"
+        "${MAYA_BASE_DIR}"
+    PATH_SUFFIXES
+        Maya.app/Contents/bin/
+        bin/
+    DOC
+        "Maya's Python executable path"
+)
+
 if(MAYA_INCLUDE_DIRS AND EXISTS "${MAYA_INCLUDE_DIR}/maya/MTypes.h")
+
+    # Tease the MAYA_API_VERSION numbers from the lib headers
     file(STRINGS ${MAYA_INCLUDE_DIR}/maya/MTypes.h TMP REGEX "#define MAYA_API_VERSION.*$")
     string(REGEX MATCHALL "[0-9]+" MAYA_API_VERSION ${TMP})
-    string(SUBSTRING ${MAYA_API_VERSION} 0 4 MAYA_API_VERSION_SHORT)
 endif()
 
 # handle the QUIETLY and REQUIRED arguments and set MAYA_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Maya DEFAULT_MSG
-    ${MAYA_LIBRARIES}
-    MAYA_INCLUDE_DIRS)
 
+find_package_handle_standard_args(Maya
+    REQUIRED_VARS
+        MAYA_EXECUTABLE
+        MAYA_PY_EXECUTABLE
+        MAYA_INCLUDE_DIRS
+        MAYA_LIBRARIES
+    VERSION_VAR
+        MAYA_API_VERSION
+)

--- a/cmake/Modules/FindXGen.cmake
+++ b/cmake/Modules/FindXGen.cmake
@@ -5,7 +5,7 @@
 #
 # This software is released under the MIT license.
 #
-# Copyright (c) 2016-2018 Esteban Tovagliari, The appleseedhq Organization
+# Copyright (c) 2016-2019 Esteban Tovagliari, The appleseedhq Organization
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,29 +38,18 @@
 if(APPLE)
   find_path(MAYA_BASE_DIR ../../devkit/include/maya/MFn.h PATH
     ENV MAYA_LOCATION
-    "/Applications/Autodesk/maya2016/Maya.app/Contents"
-    "/Applications/Autodesk/maya2015/Maya.app/Contents"
-    "/Applications/Autodesk/maya2014/Maya.app/Contents"
-    "/Applications/Autodesk/maya2013/Maya.app/Contents"
-    "/Applications/Autodesk/maya2012.17/Maya.app/Contents"
-    "/Applications/Autodesk/maya2012/Maya.app/Contents"
-    "/Applications/Autodesk/maya2011/Maya.app/Contents"
-    "/Applications/Autodesk/maya2010/Maya.app/Contents"
-  )
+    "/Applications/Autodesk/maya2019/Maya.app/Contents"
+    "/Applications/Autodesk/maya2018/Maya.app/Contents"
+    "/Applications/Autodesk/maya2017/Maya.app/Contents"
 endif(APPLE)
 
 if(UNIX)
   find_path(MAYA_BASE_DIR include/maya/MFn.h
     PATH
       ENV MAYA_LOCATION
-      "/usr/autodesk/maya2016"
-      "/usr/autodesk/maya2015-x64"
-      "/usr/autodesk/maya2014-x64"
-      "/usr/autodesk/maya2013-x64"
-      "/usr/autodesk/maya2012.17-x64"
-      "/usr/autodesk/maya2012-x64"
-      "/usr/autodesk/maya2011-x64"
-      "/usr/autodesk/maya2010-x64"
+      "/usr/autodesk/maya2019"
+      "/usr/autodesk/maya2018"
+      "/usr/autodesk/maya2017"
   )
 endif(UNIX)
 
@@ -68,22 +57,8 @@ if(WIN32)
   find_path(MAYA_BASE_DIR include/maya/MFn.h
     PATH
       ENV MAYA_LOCATION
-        "C:/Program Files/Autodesk/Maya2016"
-        "C:/Program Files/Autodesk/Maya2015"
-        "C:/Program Files/Autodesk/Maya2014"
-        "C:/Program Files/Autodesk/Maya2013"
-        "C:/Program Files/Autodesk/Maya2012-x64"
-        "C:/Program Files/Autodesk/Maya2012"
-        "C:/Program Files (x86)/Autodesk/Maya2012"
-        "C:/Autodesk/maya-2012x64"
-        "C:/Program Files/Autodesk/Maya2011-x64"
-        "C:/Program Files/Autodesk/Maya2011"
-        "C:/Program Files (x86)/Autodesk/Maya2011"
-        "C:/Autodesk/maya-2011x64"
-        "C:/Program Files/Autodesk/Maya2010-x64"
-        "C:/Program Files/Autodesk/Maya2010"
-        "C:/Program Files (x86)/Autodesk/Maya2010"
-        "C:/Autodesk/maya-2010x64"
+        "C:/Program Files/Autodesk/Maya2019"
+        "C:/Program Files/Autodesk/Maya2018"
   )
 endif(WIN32)
 


### PR DESCRIPTION
- Align minimum version requirements for Boost and cmake with the one for appleseed core 
- Drop build support for Maya 2017 Windows due to deprecation of VS-2012 support in appleseed