### PR TITLE
Rename Create Sky Dome to Create Dome Light

### DIFF
--- a/scripts/appleseedMaya/menu.py
+++ b/scripts/appleseedMaya/menu.py
@@ -111,7 +111,7 @@ def createMenu():
         to=True,
         parent='appleseedMenu')
     mc.menuItem(
-        label='Create Sky Dome',
+        label='Create Dome Light',
         parent='appleseedLightMenu',
         command='import appleseedMaya.menu\nappleseedMaya.menu.createSkyDomeLight()')
     mc.menuItem(


### PR DESCRIPTION
- Renamed `Create Sky Dome` to `Create Dome Light` to avoid confusion with `Create Physical Sky` 