### PR TITLE
Expose shadow terminator correction factor

### DIFF
--- a/scripts/appleseedMaya/AETemplates/__init__.py
+++ b/scripts/appleseedMaya/AETemplates/__init__.py
@@ -128,6 +128,8 @@ class AEappleseedNodeTemplate(pm.ui.AETemplate):
             self.addControl('asSubsurfaceSet', label='SSS Set')
             self.addSeparator()
             self.addControl('asIsPhotonTarget', label='SPPM Photon Target')
+            self.addSeparator()
+            self.addControl('asShadowTerminatorCorrection', label='Shadow Terminator Fix')
             self.endLayout()
 
             self.beginLayout('Export', collapse=1)
@@ -135,15 +137,6 @@ class AEappleseedNodeTemplate(pm.ui.AETemplate):
             self.addControl('asExportNormals', label='Export Normals')
             self.addControl('asSmoothTangents', label='Smooth Tangents')
             self.endLayout()
-
-            """
-            # Ray bias isn't working as expected yet, disable it for now.
-            self.beginLayout('Advanced', collapse=1)
-            self.addControl('asRayBiasMethod', label='Ray Bias Method')
-            self.addSeparator()
-            self.addControl('asRayBiasDistance', label='Ray Bias Distance')
-            self.endLayout()
-            """
 
             self.endLayout()
 

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -391,6 +391,10 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
         self._uis["minPixelSamples"].setEnable(value)
         self._uis["batchSampleSize"].setEnable(value)
         self._uis["sampleNoiseThreshold"].setEnable(value)
+        if value:
+            mc.setAttr("appleseedRenderGlobals.samples", 256)
+        else:
+            mc.setAttr("appleseedRenderGlobals.samples", 32)
 
     def __motionBlurChanged(self, value):
         self._uis["mbCameraSamples"].setEnable(value)

--- a/src/appleseedmaya/exporters/shapeexporter.cpp
+++ b/src/appleseedmaya/exporters/shapeexporter.cpp
@@ -162,6 +162,10 @@ void ShapeExporter::createObjectInstance(const MString& objectName)
         bool isPhotonTarget = false;
         if (AttributeUtils::get(node(), "asIsPhotonTarget", isPhotonTarget))
             params.insert("photon_target", isPhotonTarget);
+
+        float shadowTerminatorCorrection = 0.0f;
+        if (AttributeUtils::get(node(), "asShadowTerminatorCorrection", shadowTerminatorCorrection))
+            params.insert("shadow_terminator_correction", shadowTerminatorCorrection);
     }
 
     m_objectInstance.reset(

--- a/src/appleseedmaya/extensionattributes.cpp
+++ b/src/appleseedmaya/extensionattributes.cpp
@@ -176,6 +176,21 @@ namespace
         AttributeUtils::makeInput(numAttrFn);
         modifier.addExtensionAttribute(nodeClass, attr);
 
+        attr = createNumericAttribute<float>(
+            numAttrFn,
+            "asShadowTerminatorCorrection",
+            "asShadowTerminatorCorrection",
+            MFnNumericData::kFloat,
+            0.0f,
+            status);
+        numAttrFn.setSoftMin(0.0f);
+        numAttrFn.setSoftMax(0.5f);
+        numAttrFn.setMin(0.0f);
+        numAttrFn.setMax(0.5f);
+        numAttrFn.setKeyable(true);
+        AttributeUtils::makeInput(numAttrFn);
+        modifier.addExtensionAttribute(nodeClass, attr);
+
         MFnTypedAttribute typedAttrFn;
         attr = typedAttrFn.create("asSubsurfaceSet", "asSubsurfaceSet", MFnData::kString);
         AttributeUtils::makeInput(typedAttrFn);
@@ -208,32 +223,6 @@ namespace
             MFnNumericData::kBoolean,
             false,
             status);
-        AttributeUtils::makeInput(numAttrFn);
-        modifier.addExtensionAttribute(nodeClass, attr);
-
-        MFnEnumAttribute enumAttrFn;
-        attr = enumAttrFn.create(
-            "asRayBiasMethod",
-            "asRayBiasMethod",
-            0);
-        enumAttrFn.addField("None", 0);
-        enumAttrFn.addField("Normal", 1);
-        enumAttrFn.addField("Incoming Direction", 2);
-        enumAttrFn.addField("Outgoing Direction", 3);
-        enumAttrFn.setKeyable(false);
-        AttributeUtils::makeInput(enumAttrFn);
-        modifier.addExtensionAttribute(nodeClass, attr);
-
-        attr = createNumericAttribute<double>(
-            numAttrFn,
-            "asRayBiasDistance",
-            "asRayBiasDistance",
-            MFnNumericData::kDouble,
-            0.0,
-            status);
-        numAttrFn.setSoftMin(0.0);
-        numAttrFn.setSoftMax(1.0);
-        numAttrFn.setKeyable(true);
         AttributeUtils::makeInput(numAttrFn);
         modifier.addExtensionAttribute(nodeClass, attr);
 

--- a/src/appleseedmaya/renderglobalsnode.cpp
+++ b/src/appleseedmaya/renderglobalsnode.cpp
@@ -240,7 +240,7 @@ MStatus RenderGlobalsNode::initialize()
     CHECKED_ADD_ATTRIBUTE(m_minPixelSamples, "minPixelSamples")
 
     // Max pixel samples.
-    m_maxPixelSamples = numAttrFn.create("samples", "samples", MFnNumericData::kInt, 128, &status);
+    m_maxPixelSamples = numAttrFn.create("samples", "samples", MFnNumericData::kInt, 32, &status);
     numAttrFn.setMin(0);
     numAttrFn.setSoftMax(1024);
     CHECKED_ADD_ATTRIBUTE(m_maxPixelSamples, "samples")


### PR DESCRIPTION
- Implements a control for changing the shadow terminator correction factor within the appleseed objects attributes.
Depends on [https://github.com/appleseedhq/appleseed/pull/2720](url)
- Removes obsolete `Ray bias` functionality 
- Adjusts `Max Samples` defaults according to the chosen sampler type.
Addresses #221 