### PR TITLE
macOS RenderGlobals usability improvements

### DIFF
--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -350,9 +350,6 @@ class AppleseedRenderGlobalsTab(object):
         pm.connectControl(ui, attr, index=connectIndex)
 
     def _addFieldSliderControl(self, attrName, **kwargs):
-        for key in ('field', 'value', 'numberOfFields'):
-            kwargs.pop(key, "")
-
         attr = pm.Attribute("appleseedRenderGlobals." + attrName)
         self._uis[attrName] = pm.attrFieldSliderGrp(
             attribute=attr,
@@ -457,8 +454,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Render Passes",
-                            field=True,
-                            value=1,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=1,
@@ -483,8 +478,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Min Samples",
-                            field=True,
-                            value=16,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=0,
@@ -496,8 +489,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Max Samples",
-                            field=True,
-                            value=128,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=16,
@@ -508,8 +499,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Batch Sample Size",
-                            field=True,
-                            value=16,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=1,
@@ -521,8 +510,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Noise Threshold",
-                            field=True,
-                            value=0.1,
                             step=0.02,
                             precision=4,
                             columnWidth=(3, 160),
@@ -545,8 +532,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Pixel Filter Size",
-                            field=True,
-                            value=1.5,
                             sliderStep=0.5,
                             precision=1,
                             columnWidth=(3, 160),
@@ -559,8 +544,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Tile Size",
-                            field=True,
-                            value=64,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=8,
@@ -585,8 +568,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Sampling Pattern Seed",
-                            field=True,
-                            value=0,
                             columnWidth=(3, 160),
                             minValue=-65536,
                             fieldMinValue=-2147483648,
@@ -618,8 +599,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Camera Samples",
-                            field=True,
-                            value=2,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=2,
@@ -631,8 +610,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Transformation Samples",
-                            field=True,
-                            value=2,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=2,
@@ -644,8 +621,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Deformation Samples",
-                            field=True,
-                            value=2,
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
                             minValue=2,
@@ -659,7 +634,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Shutter Open",
-                            field=True, value=-0.25,
                             sliderStep=0.05,
                             precision=2,
                             columnWidth=(3, 160),
@@ -673,8 +647,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Shutter Close",
-                            field=True,
-                            value=0.25,
                             sliderStep=0.05,
                             precision=2,
                             columnWidth=(3, 160),
@@ -696,8 +668,6 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         self._addFieldSliderControl(
                             label="Scene Scale",
-                            field=True,
-                            value=1.0,
                             sliderStep=0.1,
                             precision=2,
                             columnWidth=(3, 160),
@@ -878,8 +848,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Global Bounces",
-                                    field=True,
-                                    value=8,
                                     columnWidth=[(1, 115), (2, 40), (3, 200)],
                                     columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                     minValue=0,
@@ -890,8 +858,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Diffuse Bounces",
-                                    field=True,
-                                    value=8,
                                     columnWidth=[(1, 115), (2, 40), (3, 200)],
                                     columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                     rowAttach=[(1, "both", 4)],
@@ -904,8 +870,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Glossy Bounces",
-                                    field=True,
-                                    value=8,
                                     columnWidth=[(1, 115), (2, 40), (3, 200)],
                                     columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                     enable=limitBounces,
@@ -917,8 +881,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Specular Bounces",
-                                    field=True,
-                                    value=8,
                                     columnWidth=[(1, 115), (2, 40), (3, 200)],
                                     columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                     enable=limitBounces,
@@ -955,8 +917,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Light Samples",
-                                    field=True,
-                                    value=1.0,
                                     sliderStep=1.0,
                                     fieldStep=0.1,
                                     precision=1,
@@ -973,8 +933,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="IBL Samples",
-                                    field=True,
-                                    value=1.0,
                                     sliderStep=1.0,
                                     fieldStep=0.1,
                                     precision=1,
@@ -990,8 +948,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Low Light Threshold",
-                                    field=True,
-                                    value=0.0,
                                     precision=6,
                                     columnWidth=[(1, 115), (2, 60), (3, 190)],
                                     columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
@@ -1030,7 +986,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 self._addFieldSliderControl(
                                     label="Max Ray Intensity",
-                                    field=True,
                                     sliderStep=1.0,
                                     fieldStep=0.1,
                                     precision=1,
@@ -1109,8 +1064,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Max Bounces",
-                                            field=True,
-                                            value=8,
                                             columnWidth=[(1, 125), (2, 40), (3, 100)],
                                             columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                             minValue=0,
@@ -1123,8 +1076,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="RR Starting Bounce",
-                                            field=True,
-                                            value=8,
                                             columnWidth=[(1, 125), (2, 40), (3, 100)],
                                             columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                             minValue=0,
@@ -1138,8 +1089,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Light Photons",
-                                            field=True,
-                                            value=1000000,
                                             minValue=100000,
                                             maxValue=10000000,
                                             fieldMinValue=0,
@@ -1154,8 +1103,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="IBL Photons",
-                                            field=True,
-                                            value=1000000,
                                             minValue=100000,
                                             maxValue=10000000,
                                             fieldMinValue=0,
@@ -1189,8 +1136,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Maximum Bounces",
-                                            field=True,
-                                            value=8,
                                             columnWidth=[(1, 125), (2, 40), (3, 100)],
                                             columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                             minValue=0,
@@ -1203,8 +1148,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="RR Starting Bounces",
-                                            field=True,
-                                            value=8,
                                             columnWidth=[(1, 125), (2, 40), (3, 100)],
                                             columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                             minValue=0,
@@ -1218,8 +1161,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Initial Search Radius",
-                                            field=True,
-                                            value=0.1,
                                             sliderStep=1.0,
                                             fieldStep=0.1,
                                             precision=3,
@@ -1234,8 +1175,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Maximum Photons",
-                                            field=True,
-                                            value=100,
                                             columnWidth=[(1, 125), (2, 60), (3, 100)],
                                             columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
                                             minValue=8,
@@ -1247,8 +1186,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Alpha",
-                                            field=True,
-                                            value=0.7,
                                             sliderStep=1.0,
                                             fieldStep=0.05,
                                             precision=3,
@@ -1279,8 +1216,6 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         self._addFieldSliderControl(
                                             label="Maximum Ray Intensity",
-                                            field=True,
-                                            value=1.0,
                                             sliderStep=1.0,
                                             fieldStep=0.1,
                                             precision=1,

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -953,56 +953,53 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 pm.separator(height=2)
 
-                                self._addControl(
-                                    ui=pm.floatSliderGrp(
-                                        label="Light Samples",
-                                        field=True,
-                                        value=1.0,
-                                        sliderStep=1.0,
-                                        fieldStep=0.1,
-                                        precision=1,
-                                        columnWidth=[(1, 115), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                        rowAttach=[(1, "both", 4)],
-                                        enable=enableDirectLighting,
-                                        minValue=0.0,
-                                        maxValue=20.0,
-                                        fieldMinValue=0.0,
-                                        fieldMaxValue=1000000.0,
-                                        annotation="Number of light samples used to estimate direct lighting."),
+                                self._addFieldSliderControl(
+                                    label="Light Samples",
+                                    field=True,
+                                    value=1.0,
+                                    sliderStep=1.0,
+                                    fieldStep=0.1,
+                                    precision=1,
+                                    columnWidth=[(1, 115), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                    rowAttach=[(1, "both", 4)],
+                                    enable=enableDirectLighting,
+                                    minValue=0.0,
+                                    maxValue=20.0,
+                                    fieldMinValue=0.0,
+                                    fieldMaxValue=1000000.0,
+                                    annotation="Number of light samples used to estimate direct lighting.",
                                     attrName="lightSamples")
 
-                                self._addControl(
-                                    ui=pm.floatSliderGrp(
-                                        label="IBL Samples",
-                                        field=True,
-                                        value=1.0,
-                                        sliderStep=1.0,
-                                        fieldStep=0.1,
-                                        precision=1,
-                                        columnWidth=[(1, 115), (2, 40), (3, 240)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                        enable=enableIBL,
-                                        minValue=0.0,
-                                        maxValue=20.0,
-                                        fieldMinValue=0.0,
-                                        fieldMaxValue=1000000.0,
-                                        annotation="Number of samples used to estimate environment or image-based lighting."),
+                                self._addFieldSliderControl(
+                                    label="IBL Samples",
+                                    field=True,
+                                    value=1.0,
+                                    sliderStep=1.0,
+                                    fieldStep=0.1,
+                                    precision=1,
+                                    columnWidth=[(1, 115), (2, 40), (3, 240)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                    enable=enableIBL,
+                                    minValue=0.0,
+                                    maxValue=20.0,
+                                    fieldMinValue=0.0,
+                                    fieldMaxValue=1000000.0,
+                                    annotation="Number of samples used to estimate environment or image-based lighting.",
                                     attrName="envSamples")
 
-                                self._addControl(
-                                    ui=pm.floatSliderGrp(
-                                        label="Low Light Threshold",
-                                        field=True,
-                                        value=0.0,
-                                        precision=6,
-                                        columnWidth=[(1, 115), (2, 60), (3, 190)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                        minValue=0.0,
-                                        maxValue=1.0,
-                                        fieldMinValue=0.0,
-                                        fieldMaxValue=1000.0,
-                                        annotation="Threshold at which shadow rays are terminated."),
+                                self._addFieldSliderControl(
+                                    label="Low Light Threshold",
+                                    field=True,
+                                    value=0.0,
+                                    precision=6,
+                                    columnWidth=[(1, 115), (2, 60), (3, 190)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                    minValue=0.0,
+                                    maxValue=1.0,
+                                    fieldMinValue=0.0,
+                                    fieldMaxValue=1000.0,
+                                    annotation="Threshold at which shadow rays are terminated.",
                                     attrName="lowLightThreshold")
 
                                 pm.separator(height=2)
@@ -1031,21 +1028,20 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 pm.separator(height=2)
 
-                                self._addControl(
-                                    ui=pm.floatSliderGrp(
-                                        label="Max Ray Intensity",
-                                        field=True,
-                                        sliderStep=1.0,
-                                        fieldStep=0.1,
-                                        precision=1,
-                                        columnWidth=[(1, 100), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                        minValue=0.0,
-                                        maxValue=2.0,
-                                        fieldMinValue=0.0,
-                                        fieldMaxValue=10000.0,
-                                        annotation="Maximum ray intensity allowed on secondary and subsequent rays.",
-                                        enable=enableMaxRayIntensity),
+                                self._addFieldSliderControl(
+                                    label="Max Ray Intensity",
+                                    field=True,
+                                    sliderStep=1.0,
+                                    fieldStep=0.1,
+                                    precision=1,
+                                    columnWidth=[(1, 100), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                    minValue=0.0,
+                                    maxValue=2.0,
+                                    fieldMinValue=0.0,
+                                    fieldMaxValue=10000.0,
+                                    annotation="Maximum ray intensity allowed on secondary and subsequent rays.",
+                                    enable=enableMaxRayIntensity,
                                     attrName="maxRayIntensity")
 
                                 pm.separator(height=2)
@@ -1220,21 +1216,20 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         pm.separator(height=2)
 
-                                        self._addControl(
-                                            ui=pm.floatSliderGrp(
-                                                label="Initial Search Radius",
-                                                field=True,
-                                                value=0.1,
-                                                sliderStep=1.0,
-                                                fieldStep=0.1,
-                                                precision=3,
-                                                columnWidth=[(1, 125), (2, 60), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                                minValue=0.01,
-                                                maxValue=0.5,
-                                                fieldMinValue=0.001,
-                                                fieldMaxValue=100.0,
-                                                annotation="Initial photon gathering radius in percent of scene diameter."),
+                                        self._addFieldSliderControl(
+                                            label="Initial Search Radius",
+                                            field=True,
+                                            value=0.1,
+                                            sliderStep=1.0,
+                                            fieldStep=0.1,
+                                            precision=3,
+                                            columnWidth=[(1, 125), (2, 60), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                            minValue=0.01,
+                                            maxValue=0.5,
+                                            fieldMinValue=0.001,
+                                            fieldMaxValue=100.0,
+                                            annotation="Initial photon gathering radius in percent of scene diameter.",
                                             attrName="radianceEstimationInitialRadius")
 
                                         self._addFieldSliderControl(
@@ -1250,21 +1245,20 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
                                             annotation="Maximum number of photons used for radiance estimation.",
                                             attrName="radianceEstimationMaxPhotons")
 
-                                        self._addControl(
-                                            ui=pm.floatSliderGrp(
-                                                label="Alpha",
-                                                field=True,
-                                                value=0.7,
-                                                sliderStep=1.0,
-                                                fieldStep=0.05,
-                                                precision=3,
-                                                columnWidth=[(1, 125), (2, 60), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                                minValue=0.0,
-                                                maxValue=1.0,
-                                                fieldMinValue=0.0,
-                                                fieldMaxValue=1.0,
-                                                annotation="Evolution rate of photon gathering radius."),
+                                        self._addFieldSliderControl(
+                                            label="Alpha",
+                                            field=True,
+                                            value=0.7,
+                                            sliderStep=1.0,
+                                            fieldStep=0.05,
+                                            precision=3,
+                                            columnWidth=[(1, 125), (2, 60), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                            minValue=0.0,
+                                            maxValue=1.0,
+                                            fieldMinValue=0.0,
+                                            fieldMaxValue=1.0,
+                                            annotation="Evolution rate of photon gathering radius.",
                                             attrName="radianceEstimationAlpha")
 
                                         pm.separator(height=2)
@@ -1283,22 +1277,21 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         pm.separator(height=2)
 
-                                        self._addControl(
-                                            ui=pm.floatSliderGrp(
-                                                label="Maximum Ray Intensity",
-                                                field=True,
-                                                value=1.0,
-                                                sliderStep=1.0,
-                                                fieldStep=0.1,
-                                                precision=1,
-                                                columnWidth=[(1, 125), (2, 40), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
-                                                minValue=0.0,
-                                                maxValue=2.0,
-                                                fieldMinValue=0.0,
-                                                fieldMaxValue=10000.0,
-                                                enable=enableMaxRayIntensitySPPM,
-                                                annotation="Maximum Ray Intensity valued allowed on secondary and subsequent rays."),
+                                        self._addFieldSliderControl(
+                                            label="Maximum Ray Intensity",
+                                            field=True,
+                                            value=1.0,
+                                            sliderStep=1.0,
+                                            fieldStep=0.1,
+                                            precision=1,
+                                            columnWidth=[(1, 125), (2, 40), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 0)],
+                                            minValue=0.0,
+                                            maxValue=2.0,
+                                            fieldMinValue=0.0,
+                                            fieldMaxValue=10000.0,
+                                            enable=enableMaxRayIntensitySPPM,
+                                            annotation="Maximum Ray Intensity valued allowed on secondary and subsequent rays.",
                                             attrName="maxRayIntensitySPPM")
 
         pm.setUITemplate("renderGlobalsTemplate", popTemplate=True)

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -287,7 +287,10 @@ def currentRendererChanged():
     # If the render globals window does not exist, create it.
     if not mc.window("unifiedRenderGlobalsWindow", exists=True):
         mel.eval("unifiedRenderGlobalsWindow")
-        mc.window("unifiedRenderGlobalsWindow", edit=True, visible=False)
+        if pm.versions.current() >= 2017000:
+            mc.workspaceControl("unifiedRenderGlobalsWindow", edit=True, visible=False)
+        else:
+            mc.window("unifiedRenderGlobalsWindow", edit=True, visible=False)
 
     # "Customize" the image formats menu.
     mc.setParent("unifiedRenderGlobalsWindow")

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -240,7 +240,8 @@ def addRenderGlobalsScriptJobs():
         ]
     )
 
-    # For opening new scene with default renderer appleseed
+    # For fixing the render globals common tab when opening new scene
+    # and the default renderer is appleseed
     mc.scriptJob(
         event=[
             'NewSceneOpened',
@@ -248,7 +249,8 @@ def addRenderGlobalsScriptJobs():
         ]
     )
 
-    # For maya startup empty scene default renderer appleseed
+    # For fixing the render globals common tab on initial startup of maya
+    # when the default renderer is appleseed
     mc.evalDeferred(python_script, lowestPriority=True)
 
 
@@ -308,8 +310,8 @@ def currentRendererChanged():
     # This can happen if currentRendererChanged is called too soon during startup
     # and unifiedRenderGlobalsWindow isn't complete or delayed for some reason.
     # Known to happen if default renderer is appleseed and the scene is opened as
-    # a commandline arg. In that case the NewSceneOpened scriptjob will be call
-    # the currentRendererChanged function again later.
+    # a commandline argument. In that case the NewSceneOpened scriptjob will call the
+    # currentRendererChanged function again later.
     if not mc.optionMenuGrp('imageMenuMayaSW', q=True, ex=True):
         logger.warn("imageMenuMayaSW does not exists yet")
         return

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -230,10 +230,13 @@ def addRenderGlobalsScriptJobs():
     g_nodeRemovedCallbackID = om.MDGMessage.addNodeRemovedCallback(
         __nodeRemoved)
 
+    # This is evalDeferred so it doesn't get
+    # called before createMayaSoftwareCommonGlobalsTab
+    python_script = "import appleseedMaya.renderGlobals; appleseedMaya.renderGlobals.currentRendererChanged()"
     mc.scriptJob(
         attributeChange=[
             "defaultRenderGlobals.currentRenderer",
-            "import appleseedMaya.renderGlobals; appleseedMaya.renderGlobals.currentRendererChanged()"
+             lambda: mc.evalDeferred(python_script, lowestPriority=True),
         ]
     )
 

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -519,20 +519,19 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
                             enable=adaptiveSampling,
                             attrName="batchSampleSize")
 
-                        self._addControl(
-                            ui=pm.floatSliderGrp(
-                                label="Noise Threshold",
-                                field=True,
-                                value=0.1,
-                                step=0.02,
-                                precision=4,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=0.0001,
-                                fieldMinValue=0.0,
-                                maxValue=2.0,
-                                fieldMaxValue=25.0,
-                                enable=adaptiveSampling),
+                        self._addFieldSliderControl(
+                            label="Noise Threshold",
+                            field=True,
+                            value=0.1,
+                            step=0.02,
+                            precision=4,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=0.0001,
+                            fieldMinValue=0.0,
+                            maxValue=2.0,
+                            fieldMaxValue=25.0,
+                            enable=adaptiveSampling,
                             attrName="sampleNoiseThreshold")
 
                         pm.separator(height=2)
@@ -544,19 +543,18 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
                                 enumeratedItem=self._getAttributeMenuItems("pixelFilter")),
                             attrName="pixelFilter")
 
-                        self._addControl(
-                            ui=pm.floatSliderGrp(
-                                label="Pixel Filter Size",
-                                field=True,
-                                value=1.5,
-                                sliderStep=0.5,
-                                precision=1,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=0.5,
-                                fieldMinValue=0.5,
-                                maxValue=4.0,
-                                fieldMaxValue=20.0),
+                        self._addFieldSliderControl(
+                            label="Pixel Filter Size",
+                            field=True,
+                            value=1.5,
+                            sliderStep=0.5,
+                            precision=1,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=0.5,
+                            fieldMinValue=0.5,
+                            maxValue=4.0,
+                            fieldMaxValue=20.0,
                             attrName="pixelFilterSize")
 
                         self._addFieldSliderControl(
@@ -659,35 +657,33 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         pm.separator(height=2)
 
-                        self._addControl(
-                            ui=pm.floatSliderGrp(
-                                label="Shutter Open",
-                                field=True, value=-0.25,
-                                sliderStep=0.05,
-                                precision=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=-1.0,
-                                fieldMinValue=-1.0,
-                                maxValue=0.0,
-                                fieldMaxValue=0.0,
-                                enable=enableMotionBlur),
+                        self._addFieldSliderControl(
+                            label="Shutter Open",
+                            field=True, value=-0.25,
+                            sliderStep=0.05,
+                            precision=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=-1.0,
+                            fieldMinValue=-1.0,
+                            maxValue=0.0,
+                            fieldMaxValue=0.0,
+                            enable=enableMotionBlur,
                             attrName="shutterOpen")
 
-                        self._addControl(
-                            ui=pm.floatSliderGrp(
-                                label="Shutter Close",
-                                field=True,
-                                value=0.25,
-                                sliderStep=0.05,
-                                precision=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=0.0,
-                                fieldMinValue=0.0,
-                                maxValue=1.0,
-                                fieldMaxValue=1.0,
-                                enable=enableMotionBlur),
+                        self._addFieldSliderControl(
+                            label="Shutter Close",
+                            field=True,
+                            value=0.25,
+                            sliderStep=0.05,
+                            precision=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=0.0,
+                            fieldMinValue=0.0,
+                            maxValue=1.0,
+                            fieldMaxValue=1.0,
+                            enable=enableMotionBlur,
                             attrName="shutterClose")
 
                         pm.separator(height=2)
@@ -698,19 +694,18 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         pm.separator(height=2)
 
-                        self._addControl(
-                            ui=pm.floatSliderGrp(
-                                label="Scene Scale",
-                                field=True,
-                                value=1.0,
-                                sliderStep=0.1,
-                                precision=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=0.01,
-                                fieldMinValue=1.0e-6,
-                                maxValue=100,
-                                fieldMaxValue=1.0e+6),
+                        self._addFieldSliderControl(
+                            label="Scene Scale",
+                            field=True,
+                            value=1.0,
+                            sliderStep=0.1,
+                            precision=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=0.01,
+                            fieldMinValue=1.0e-6,
+                            maxValue=100,
+                            fieldMaxValue=1.0e+6,
                             attrName="sceneScale")
 
                         pm.separator(height=2)

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -881,60 +881,56 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
                                 enableDirectLighting = mc.getAttr(
                                     "appleseedRenderGlobals.enableDirectLighting")
 
-                                self._addControl(
-                                    ui=pm.intSliderGrp(
-                                        label="Global Bounces",
-                                        field=True,
-                                        value=8,
-                                        columnWidth=[(1, 115), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                        minValue=0,
-                                        maxValue=30,
-                                        fieldMinValue=0,
-                                        fieldMaxValue=100),
+                                self._addFieldSliderControl(
+                                    label="Global Bounces",
+                                    field=True,
+                                    value=8,
+                                    columnWidth=[(1, 115), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                    minValue=0,
+                                    maxValue=30,
+                                    fieldMinValue=0,
+                                    fieldMaxValue=100,
                                     attrName="bounces")
 
-                                self._addControl(
-                                    ui=pm.intSliderGrp(
-                                        label="Diffuse Bounces",
-                                        field=True,
-                                        value=8,
-                                        columnWidth=[(1, 115), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                        rowAttach=[(1, "both", 4)],
-                                        enable=limitBounces,
-                                        minValue=0,
-                                        maxValue=30,
-                                        fieldMinValue=0,
-                                        fieldMaxValue=100),
+                                self._addFieldSliderControl(
+                                    label="Diffuse Bounces",
+                                    field=True,
+                                    value=8,
+                                    columnWidth=[(1, 115), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                    rowAttach=[(1, "both", 4)],
+                                    enable=limitBounces,
+                                    minValue=0,
+                                    maxValue=30,
+                                    fieldMinValue=0,
+                                    fieldMaxValue=100,
                                     attrName="diffuseBounces")
 
-                                self._addControl(
-                                    ui=pm.intSliderGrp(
-                                        label="Glossy Bounces",
-                                        field=True,
-                                        value=8,
-                                        columnWidth=[(1, 115), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                        enable=limitBounces,
-                                        minValue=0,
-                                        maxValue=30,
-                                        fieldMinValue=0,
-                                        fieldMaxValue=100),
+                                self._addFieldSliderControl(
+                                    label="Glossy Bounces",
+                                    field=True,
+                                    value=8,
+                                    columnWidth=[(1, 115), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                    enable=limitBounces,
+                                    minValue=0,
+                                    maxValue=30,
+                                    fieldMinValue=0,
+                                    fieldMaxValue=100,
                                     attrName="glossyBounces")
 
-                                self._addControl(
-                                    ui=pm.intSliderGrp(
-                                        label="Specular Bounces",
-                                        field=True,
-                                        value=8,
-                                        columnWidth=[(1, 115), (2, 40), (3, 200)],
-                                        columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                        enable=limitBounces,
-                                        minValue=0,
-                                        maxValue=30,
-                                        fieldMinValue=0,
-                                        fieldMaxValue=100),
+                                self._addFieldSliderControl(
+                                    label="Specular Bounces",
+                                    field=True,
+                                    value=8,
+                                    columnWidth=[(1, 115), (2, 40), (3, 200)],
+                                    columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                    enable=limitBounces,
+                                    minValue=0,
+                                    maxValue=30,
+                                    fieldMinValue=0,
+                                    fieldMaxValue=100,
                                     attrName="specularBounces")
 
                                 pm.separator(height=2)
@@ -1120,67 +1116,63 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         pm.separator(height=2)
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="Max Bounces",
-                                                field=True,
-                                                value=8,
-                                                columnWidth=[(1, 125), (2, 40), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                minValue=0,
-                                                maxValue=30,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100,
-                                                annotation="Maximum number of photon bounces.",
-                                                enable=limitPhotonTracingBounces),
+                                        self._addFieldSliderControl(
+                                            label="Max Bounces",
+                                            field=True,
+                                            value=8,
+                                            columnWidth=[(1, 125), (2, 40), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            minValue=0,
+                                            maxValue=30,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100,
+                                            annotation="Maximum number of photon bounces.",
+                                            enable=limitPhotonTracingBounces,
                                             attrName="photonTracingBounces")
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="RR Starting Bounce",
-                                                field=True,
-                                                value=8,
-                                                columnWidth=[(1, 125), (2, 40), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                minValue=0,
-                                                maxValue=30,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100,
-                                                annotation="Discard low contribution paths starting with this bounce."),
+                                        self._addFieldSliderControl(
+                                            label="RR Starting Bounce",
+                                            field=True,
+                                            value=8,
+                                            columnWidth=[(1, 125), (2, 40), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            minValue=0,
+                                            maxValue=30,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100,
+                                            annotation="Discard low contribution paths starting with this bounce.",
                                             attrName="photonTracingRRMinPathLength")
 
                                         pm.separator(height=2)
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="Light Photons",
-                                                field=True,
-                                                value=1000000,
-                                                minValue=100000,
-                                                maxValue=10000000,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100000000,
-                                                columnWidth=[(1, 125), (2, 60), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                annotation="Number of light photons per render pass."),
+                                        self._addFieldSliderControl(
+                                            label="Light Photons",
+                                            field=True,
+                                            value=1000000,
+                                            minValue=100000,
+                                            maxValue=10000000,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100000000,
+                                            columnWidth=[(1, 125), (2, 60), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            annotation="Number of light photons per render pass.",
                                             attrName="photonTracingLightPhotons")
 
                                         SPPMEnableIBL = mc.getAttr(
                                             "appleseedRenderGlobals.SPPMEnableIBL")
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="IBL Photons",
-                                                field=True,
-                                                value=1000000,
-                                                minValue=100000,
-                                                maxValue=10000000,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100000000,
-                                                columnWidth=[(1, 125), (2, 60), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                enable=SPPMEnableIBL,
-                                                annotation="Number of environment photons per render pass."),
+                                        self._addFieldSliderControl(
+                                            label="IBL Photons",
+                                            field=True,
+                                            value=1000000,
+                                            minValue=100000,
+                                            maxValue=10000000,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100000000,
+                                            columnWidth=[(1, 125), (2, 60), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            enable=SPPMEnableIBL,
+                                            annotation="Number of environment photons per render pass.",
                                             attrName="photonTracingEnvPhotons")
 
                                 with pm.frameLayout("sppmRadianceEstimationFrameLayout", font="smallBoldLabelFont",
@@ -1204,33 +1196,31 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                         pm.separator(height=2)
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="Maximum Bounces",
-                                                field=True,
-                                                value=8,
-                                                columnWidth=[(1, 125), (2, 40), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                minValue=0,
-                                                maxValue=30,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100,
-                                                enable=limitRadianceEstimationBounces,
-                                                annotation="Maximum number of radiance estimation path bounces."),
+                                        self._addFieldSliderControl(
+                                            label="Maximum Bounces",
+                                            field=True,
+                                            value=8,
+                                            columnWidth=[(1, 125), (2, 40), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            minValue=0,
+                                            maxValue=30,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100,
+                                            enable=limitRadianceEstimationBounces,
+                                            annotation="Maximum number of radiance estimation path bounces.",
                                             attrName="radianceEstimationBounces")
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="RR Starting Bounces",
-                                                field=True,
-                                                value=8,
-                                                columnWidth=[(1, 125), (2, 40), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                minValue=0,
-                                                maxValue=30,
-                                                fieldMinValue=0,
-                                                fieldMaxValue=100,
-                                                annotation="Discard low contribution paths starting with this bounce."),
+                                        self._addFieldSliderControl(
+                                            label="RR Starting Bounces",
+                                            field=True,
+                                            value=8,
+                                            columnWidth=[(1, 125), (2, 40), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            minValue=0,
+                                            maxValue=30,
+                                            fieldMinValue=0,
+                                            fieldMaxValue=100,
+                                            annotation="Discard low contribution paths starting with this bounce.",
                                             attrName="radianceEstimationRRMinPathLength")
 
                                         pm.separator(height=2)
@@ -1252,18 +1242,17 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
                                                 annotation="Initial photon gathering radius in percent of scene diameter."),
                                             attrName="radianceEstimationInitialRadius")
 
-                                        self._addControl(
-                                            ui=pm.intSliderGrp(
-                                                label="Maximum Photons",
-                                                field=True,
-                                                value=100,
-                                                columnWidth=[(1, 125), (2, 60), (3, 100)],
-                                                columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
-                                                minValue=8,
-                                                maxValue=500,
-                                                fieldMinValue=8,
-                                                fieldMaxValue=1000000000,
-                                                annotation="Maximum number of photons used for radiance estimation."),
+                                        self._addFieldSliderControl(
+                                            label="Maximum Photons",
+                                            field=True,
+                                            value=100,
+                                            columnWidth=[(1, 125), (2, 60), (3, 100)],
+                                            columnAttach=[(1, "right", 4), (2, "right", 2), (3, "right", 8)],
+                                            minValue=8,
+                                            maxValue=500,
+                                            fieldMinValue=8,
+                                            fieldMaxValue=1000000000,
+                                            annotation="Maximum number of photons used for radiance estimation.",
                                             attrName="radianceEstimationMaxPhotons")
 
                                         self._addControl(

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -349,6 +349,15 @@ class AppleseedRenderGlobalsTab(object):
         attr = pm.Attribute("appleseedRenderGlobals." + attrName)
         pm.connectControl(ui, attr, index=connectIndex)
 
+    def _addFieldSliderControl(self, attrName, **kwargs):
+        for key in ('field', 'value', 'numberOfFields'):
+            kwargs.pop(key, "")
+
+        attr = pm.Attribute("appleseedRenderGlobals." + attrName)
+        self._uis[attrName] = pm.attrFieldSliderGrp(
+            attribute=attr,
+            **kwargs)
+
     def _getAttributeMenuItems(self, attrName):
         attr = pm.Attribute("appleseedRenderGlobals." + attrName)
         menuItems = [
@@ -446,17 +455,16 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         pm.separator(height=2)
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Render Passes",
-                                field=True,
-                                value=1,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=1,
-                                fieldMinValue=1,
-                                maxValue=100,
-                                fieldMaxValue=1000000),
+                        self._addFieldSliderControl(
+                            label="Render Passes",
+                            field=True,
+                            value=1,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=1,
+                            fieldMinValue=1,
+                            maxValue=100,
+                            fieldMaxValue=1000000,
                             attrName="passes")
 
                         pm.separator(height=2)
@@ -473,45 +481,42 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         adaptiveSampling = mc.getAttr("appleseedRenderGlobals.adaptiveSampling")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Min Samples",
-                                field=True,
-                                value=16,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=0,
-                                fieldMinValue=0,
-                                maxValue=256,
-                                fieldMaxValue=1000000,
-                                enable=adaptiveSampling),
+                        self._addFieldSliderControl(
+                            label="Min Samples",
+                            field=True,
+                            value=16,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=0,
+                            fieldMinValue=0,
+                            maxValue=256,
+                            fieldMaxValue=1000000,
+                            enable=adaptiveSampling,
                             attrName="minPixelSamples")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Max Samples",
-                                field=True,
-                                value=128,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=16,
-                                fieldMinValue=0,
-                                maxValue=1024,
-                                fieldMaxValue=1000000),
+                        self._addFieldSliderControl(
+                            label="Max Samples",
+                            field=True,
+                            value=128,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=16,
+                            fieldMinValue=0,
+                            maxValue=1024,
+                            fieldMaxValue=1000000,
                             attrName="samples")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Batch Sample Size",
-                                field=True,
-                                value=16,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=1,
-                                fieldMinValue=1,
-                                maxValue=128,
-                                fieldMaxValue=1000000,
-                                enable=adaptiveSampling),
+                        self._addFieldSliderControl(
+                            label="Batch Sample Size",
+                            field=True,
+                            value=16,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=1,
+                            fieldMinValue=1,
+                            maxValue=128,
+                            fieldMaxValue=1000000,
+                            enable=adaptiveSampling,
                             attrName="batchSampleSize")
 
                         self._addControl(
@@ -554,17 +559,16 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
                                 fieldMaxValue=20.0),
                             attrName="pixelFilterSize")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Tile Size",
-                                field=True,
-                                value=64,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=8,
-                                fieldMinValue=1,
-                                maxValue=1024,
-                                fieldMaxValue=65536),
+                        self._addFieldSliderControl(
+                            label="Tile Size",
+                            field=True,
+                            value=64,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=8,
+                            fieldMinValue=1,
+                            maxValue=1024,
+                            fieldMaxValue=65536,
                             attrName="tileSize")
 
                         pm.separator(height=2)
@@ -581,17 +585,16 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
 
                         pm.separator(height=2)
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Sampling Pattern Seed",
-                                field=True,
-                                value=0,
-                                columnWidth=(3, 160),
-                                minValue=-65536,
-                                fieldMinValue=-2147483648,
-                                maxValue=65535,
-                                enable=lockSamplingPattern,
-                                fieldMaxValue=2147483647),
+                        self._addFieldSliderControl(
+                            label="Sampling Pattern Seed",
+                            field=True,
+                            value=0,
+                            columnWidth=(3, 160),
+                            minValue=-65536,
+                            fieldMinValue=-2147483648,
+                            maxValue=65535,
+                            enable=lockSamplingPattern,
+                            fieldMaxValue=2147483647,
                             attrName="noiseSeed")
 
                         pm.separator(height=2)
@@ -615,46 +618,43 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
                         enableMotionBlur = mc.getAttr(
                             "appleseedRenderGlobals.motionBlur")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Camera Samples",
-                                field=True,
-                                value=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=2,
-                                fieldMinValue=2,
-                                maxValue=30,
-                                fieldMaxValue=1000,
-                                enable=enableMotionBlur),
+                        self._addFieldSliderControl(
+                            label="Camera Samples",
+                            field=True,
+                            value=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=2,
+                            fieldMinValue=2,
+                            maxValue=30,
+                            fieldMaxValue=1000,
+                            enable=enableMotionBlur,
                             attrName="mbCameraSamples")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Transformation Samples",
-                                field=True,
-                                value=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=2,
-                                fieldMinValue=2,
-                                maxValue=30,
-                                fieldMaxValue=1000,
-                                enable=enableMotionBlur),
+                        self._addFieldSliderControl(
+                            label="Transformation Samples",
+                            field=True,
+                            value=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=2,
+                            fieldMinValue=2,
+                            maxValue=30,
+                            fieldMaxValue=1000,
+                            enable=enableMotionBlur,
                             attrName="mbTransformSamples")
 
-                        self._addControl(
-                            ui=pm.intSliderGrp(
-                                label="Deformation Samples",
-                                field=True,
-                                value=2,
-                                columnWidth=(3, 160),
-                                columnAttach=(1, "right", 4),
-                                minValue=2,
-                                fieldMinValue=2,
-                                maxValue=30,
-                                fieldMaxValue=1000,
-                                enable=enableMotionBlur),
+                        self._addFieldSliderControl(
+                            label="Deformation Samples",
+                            field=True,
+                            value=2,
+                            columnWidth=(3, 160),
+                            columnAttach=(1, "right", 4),
+                            minValue=2,
+                            fieldMinValue=2,
+                            maxValue=30,
+                            fieldMaxValue=1000,
+                            enable=enableMotionBlur,
                             attrName="mbDeformSamples")
 
                         pm.separator(height=2)
@@ -1689,4 +1689,3 @@ class AppleseedRenderGlobalsSystemTab(AppleseedRenderGlobalsTab):
 
 
 g_appleseedSystemTab = AppleseedRenderGlobalsSystemTab()
-

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -266,9 +266,11 @@ def imageFormatChanged():
     if newFormat == 0:  # EXR
         mc.setAttr("defaultRenderGlobals.imageFormat", 51)
         mc.setAttr("defaultRenderGlobals.imfkey", "exr", type="string")
+        mc.optionMenuGrp("imageMenuMayaSW", edit=True, select=newFormat + 1)
     elif newFormat == 1:  # PNG
         mc.setAttr("defaultRenderGlobals.imageFormat", 32)
         mc.setAttr("defaultRenderGlobals.imfkey", "png", type="string")
+        mc.optionMenuGrp("imageMenuMayaSW", edit=True, select=newFormat + 1)
     else:
         raise RuntimeError("Unknown render global image file format")
 


### PR DESCRIPTION
The follow pull request fixes a bunch of RenderGlobals usability issues I've found on macOS.
- Fixes a bug that prevents RenderGlobals from opening in some cases.
- Fixes issue causing RenderGlobals to go blank.
    The RenderGlobals may still pop on and off when opening a file but at least it works.
- Image format restores properly when reopening RenderGlobals.
- `IntSliderGrp` and `floatSliderGrp` sliders don't appear to work 
     with `connectControl` on macOS, using `attrFieldSliderGrp` instead.