### PR TITLE
Fix handling of medium priority and photon target params

### DIFF
--- a/src/appleseedmaya/exporters/meshexporter.cpp
+++ b/src/appleseedmaya/exporters/meshexporter.cpp
@@ -435,32 +435,9 @@ MurmurHash MeshExporter::hash() const
     return m_hash;
 }
 
+// Insert mesh object params here.
 void MeshExporter::meshAttributesToParams(renderer::ParamArray& params)
 {
-    int mediumPriority = 0;
-    if (AttributeUtils::get(node(), "asMediumPriority", mediumPriority))
-        params.insert("medium_priority", mediumPriority);
-
-    bool isPhotonTarget = false;
-    if (AttributeUtils::get(node(), "asIsPhotonTarget", isPhotonTarget))
-        params.insert("photon_target", isPhotonTarget);
-
-    short rayBiasMethodIndex = 0; // MFnEnumAttr index is short
-
-#if 0
-    // Ray bias isn't fully working, hide it for now.
-    if (AttributeUtils::get(node(), "asRayBiasMethod", rayBiasMethodIndex))
-    {
-        const std::array<std::string, 4> biasMethods = {
-            "none", "normal", "incoming_direction", "outgoing_direction"
-        };
-        params.insert("ray_bias_method", biasMethods.at(static_cast<size_t>(rayBiasMethodIndex)));
-    }
-
-    double rayBiasDistance = 0.0;
-    if (AttributeUtils::get(node(), "asRayBiasDistance", rayBiasDistance))
-        params.insert("ray_bias_distance", rayBiasDistance);
-#endif
 }
 
 int MeshExporter::getSmoothLevel(MStatus* ReturnStatus) const

--- a/src/appleseedmaya/exporters/shapeexporter.cpp
+++ b/src/appleseedmaya/exporters/shapeexporter.cpp
@@ -154,6 +154,14 @@ void ShapeExporter::createObjectInstance(const MString& objectName)
             if (sssSet.length() != 0)
                 params.insert_path("sss_set_id", sssSet.asChar());
         }
+
+        int mediumPriority = 0;
+        if (AttributeUtils::get(node(), "asMediumPriority", mediumPriority))
+            params.insert("medium_priority", mediumPriority);
+
+        bool isPhotonTarget = false;
+        if (AttributeUtils::get(node(), "asIsPhotonTarget", isPhotonTarget))
+            params.insert("photon_target", isPhotonTarget);
     }
 
     m_objectInstance.reset(


### PR DESCRIPTION
Medium Priority and Photon Target were wrongly exported as (mesh) object parameters.
This code change will export them as object instance parameter instead.
