### PR TITLE
Enable sphinx 1.8

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Sphinx 1.7.1 fails with sphinxcontrib-images, force 1.6.7
-sphinx==1.6.7
+sphinx==1.8.2
 
 # Sphinx-bootstrap-theme
 sphinx-bootstrap-theme
@@ -11,7 +11,7 @@ sphinxcontrib-bibtex
 sphinxcontrib-images
 
 # extra CSS3 image options
-sphinxcontrib-css3image
+# sphinxcontrib-css3image
 
 # run console, python code
 sphinx-autorun

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from docutils.parsers.rst.directives.admonitions import BaseAdmonition
 from sphinx.util import compat
 compat.make_admonition = BaseAdmonition
 
-needs_sphinx = '1.6'
+needs_sphinx = '1.8'
 
 # For automagical GIT versioning (describe, tags)
 #
@@ -61,7 +61,7 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.bibtex',
     'sphinxcontrib.images',
-    'sphinxcontrib.css3image',
+#    'sphinxcontrib.css3image',
     'sphinx_autorun'
     ]
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,6 @@ Contents
     installation/installation
     features/supported_nodes
     shaders/shaders
-    tutorials/tutorials
     about/about
     bibliography/bibliography
 


### PR DESCRIPTION
And disable the 1.6.7 requirement, which also requires disabling the tutorials since they depend on a no longer supported extension (css3images).
