### PR TITLE
Add Importon Tracing control to SPPM settings

### DIFF
--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -517,7 +517,7 @@ class AppleseedRenderGlobalsMainTab(AppleseedRenderGlobalsTab):
                             label="Max Samples",
                             columnWidth=(3, 160),
                             columnAttach=(1, "right", 4),
-                            minValue=16,
+                            minValue=1,
                             fieldMinValue=0,
                             maxValue=1024,
                             fieldMaxValue=1000000,
@@ -1071,10 +1071,9 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
 
                                 with pm.frameLayout("sppmPhotonTracingFrameLayout", font="smallBoldLabelFont",
                                                     label="Photon Tracing", collapsable=False, collapse=True):
-                                    with pm.columnLayout("sppmPhotonTracingColumnLayout", adjustableColumn=True,
-                                                         width=g_subColumnWidth - g_margin, rowSpacing=2):
-                                        pm.separator(height=2)
 
+                                    with pm.rowColumnLayout("sppmCheckBoxesRowColumnLayout", numberOfRows=1):
+                                        pm.separator(height=2)
                                         self._addControl(
                                             ui=pm.checkBoxGrp(
                                                 label="Limit Bounces",
@@ -1086,6 +1085,15 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
                                         limitPhotonTracingBounces = mc.getAttr(
                                             "appleseedRenderGlobals.limitPhotonTracingBounces")
 
+                                        self._addControl(
+                                            ui=pm.checkBoxGrp(
+                                                label="Importon Tracing",
+                                                columnAttach=(1, "right", 5),
+                                                annotation="Importons are traced to determine important parts of the scene and later photons are only stored in these important parts"),
+                                            attrName="SPPMEnableImportons")
+
+                                    with pm.columnLayout("sppmPhotonTracingColumnLayout", adjustableColumn=True,
+                                        width=g_subColumnWidth - g_margin, rowSpacing=2):
                                         pm.separator(height=2)
 
                                         self._addFieldSliderControl(
@@ -1206,7 +1214,7 @@ class AppleseedRenderGlobalsLightingTab(AppleseedRenderGlobalsTab):
                                             minValue=8,
                                             maxValue=500,
                                             fieldMinValue=8,
-                                            fieldMaxValue=1000000000,
+                                            fieldMaxValue=10000,
                                             annotation="Maximum number of photons used for radiance estimation.",
                                             attrName="radianceEstimationMaxPhotons")
 

--- a/src/appleseedmaya/renderglobalsnode.cpp
+++ b/src/appleseedmaya/renderglobalsnode.cpp
@@ -123,6 +123,7 @@ MObject RenderGlobalsNode::m_sppm_radiance_estimation_max_photons;
 MObject RenderGlobalsNode::m_sppm_radiance_estimation_alpha;
 MObject RenderGlobalsNode::m_sppm_max_ray_intensity_set;
 MObject RenderGlobalsNode::m_sppm_max_ray_intensity;
+MObject RenderGlobalsNode::m_sppm_enable_importons;
 
 MObject RenderGlobalsNode::m_backgroundEmitsLight;
 MObject RenderGlobalsNode::m_envLightNode;
@@ -518,6 +519,14 @@ MStatus RenderGlobalsNode::initialize()
     numAttrFn.setMax(1000.0);
     CHECKED_ADD_ATTRIBUTE(m_sppm_max_ray_intensity, "maxRayIntensitySPPM")
 
+    // SPPM Importon tracing.
+    m_sppm_enable_importons = numAttrFn.create("SPPMEnableImportons", "SPPMEnableImportons", MFnNumericData::kBoolean, true, &status);
+    CHECKED_ADD_ATTRIBUTE(m_sppm_enable_importons, "SPPMEnableImportons")
+
+    //
+    // Motion blur.
+    //
+
     // Motion blur enable.
     m_motionBlur = numAttrFn.create("motionBlur", "motionBlur", MFnNumericData::kBoolean, false, &status);
     CHECKED_ADD_ATTRIBUTE(m_motionBlur, "motionBlur")
@@ -852,7 +861,7 @@ void RenderGlobalsNode::applyGlobalsToProject(
         INSERT_PATH_IN_CONFIGS("light_sampler.enable_importance_sampling", enableLightImportanceSampling);
 
     //
-    // Path Tracing
+    // Path Tracing.
     //
 
     // Direct lighting parameters.
@@ -1020,7 +1029,14 @@ void RenderGlobalsNode::applyGlobalsToProject(
             INSERT_PATH_IN_CONFIGS("sppm.path_tracing_max_ray_intensity", sppm_max_ray_int);
     }
 
+    bool SPPMEnableImportons = true;
+    if (AttributeUtils::get(MPlug(globals, m_sppm_enable_importons), SPPMEnableImportons))
+        INSERT_PATH_IN_CONFIGS("sppm.enable_importons", SPPMEnableImportons);
+
+    //
     // Sytem params.
+    //
+
     // Only save rendering threads for interactive renders.
     if (sessionMode == AppleseedSession::FinalRenderSession ||
         sessionMode == AppleseedSession::ProgressiveRenderSession)
@@ -1047,7 +1063,10 @@ void RenderGlobalsNode::applyGlobalsToProject(
     if (AttributeUtils::get(MPlug(globals, m_useEmbree), useEmbree))
         INSERT_PATH_IN_CONFIGS("use_embree", useEmbree)
 
+    //
     // Denoiser params.
+    //
+
     int denoiserMode;
     if (AttributeUtils::get(MPlug(globals, m_denoiserMode), denoiserMode))
     {
@@ -1097,7 +1116,10 @@ void RenderGlobalsNode::applyGlobalsToProject(
             "denoise_scales", denoiseScales);
     }
 
+    //
     // AOVs.
+    //
+
     if (sessionMode != AppleseedSession::ProgressiveRenderSession)
     {
         asr::AOVFactoryRegistrar registrar;

--- a/src/appleseedmaya/renderglobalsnode.h
+++ b/src/appleseedmaya/renderglobalsnode.h
@@ -150,6 +150,7 @@ class RenderGlobalsNode
     static MObject      m_sppm_radiance_estimation_alpha;
     static MObject      m_sppm_max_ray_intensity_set;
     static MObject      m_sppm_max_ray_intensity;
+    static MObject      m_sppm_enable_importons;
 
     // Motion blur.
     static MObject      m_motionBlur;


### PR DESCRIPTION
- Adds a checkbox to enable/disable Importon Tracing in the SPPM render settings (default is enabled)