### PR TITLE
Add cmake build support for Maya 2020

### DIFF
--- a/cmake/Modules/FindMaya.cmake
+++ b/cmake/Modules/FindMaya.cmake
@@ -32,9 +32,9 @@ if(APPLE)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
+            "/Applications/Autodesk/maya2020"
             "/Applications/Autodesk/maya2019"
             "/Applications/Autodesk/maya2018"
-            "/Applications/Autodesk/maya2017"
         DOC
             "Maya installation root directory"
     )
@@ -55,9 +55,8 @@ elseif(UNIX)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
+            "/usr/autodesk/maya2020"
             "/usr/autodesk/maya2019"
-            "/usr/autodesk/maya2018"
-            "/usr/autodesk/maya2017"
         DOC
             "Maya installation root directory"
     )
@@ -78,6 +77,8 @@ elseif(WIN32)
         HINTS
             "${MAYA_LOCATION}"
             "$ENV{MAYA_LOCATION}"
+            ${MAYA_DEFAULT_LOCATION}
+            "C:/Program Files/Autodesk/Maya2020"
             "C:/Program Files/Autodesk/Maya2019"
             "C:/Program Files/Autodesk/Maya2018"
         DOC
@@ -90,6 +91,7 @@ elseif(WIN32)
             "$ENV{MAYA_LOCATION}"
             "${MAYA_BASE_DIR}"
         PATH_SUFFIXES
+            ${LIB_SUFFIX}
             lib/
         DOC
             "Maya's libraries path"
@@ -99,7 +101,8 @@ endif()
 find_path(MAYA_INCLUDE_DIR
         maya/MFn.h
     HINTS
-        "${MAYA_LOCATION}"
+        ${MAYA_LOCATION}
+        ${MAYA_DEFAULT_LOCATION}
         "$ENV{MAYA_LOCATION}"
         "${MAYA_BASE_DIR}"
     PATH_SUFFIXES
@@ -110,12 +113,14 @@ find_path(MAYA_INCLUDE_DIR
 )
 
 find_path(MAYA_LIBRARY_DIR
-        OpenMaya
+        ${OPEN_MAYA}
     HINTS
-        "${MAYA_LOCATION}"
-        "$ENV{MAYA_LOCATION}"
+        ${MAYA_LOCATION}
+        $ENV{MAYA_LOCATION}
+        ${MAYA_DEFAULT_LOCATION}
         "${MAYA_BASE_DIR}"
     PATH_SUFFIXES
+        ../../lib/
         ../../devkit/include/
         include/
     DOC

--- a/cmake/Modules/FindXGen.cmake
+++ b/cmake/Modules/FindXGen.cmake
@@ -38,9 +38,9 @@
 if(APPLE)
   find_path(MAYA_BASE_DIR ../../devkit/include/maya/MFn.h PATH
     ENV MAYA_LOCATION
+    "/Applications/Autodesk/maya2020/Maya.app/Contents"
     "/Applications/Autodesk/maya2019/Maya.app/Contents"
     "/Applications/Autodesk/maya2018/Maya.app/Contents"
-    "/Applications/Autodesk/maya2017/Maya.app/Contents"
   )
 endif(APPLE)
 
@@ -48,9 +48,8 @@ if(UNIX)
   find_path(MAYA_BASE_DIR include/maya/MFn.h
     PATH
       ENV MAYA_LOCATION
+      "/usr/autodesk/maya2020"
       "/usr/autodesk/maya2019"
-      "/usr/autodesk/maya2018"
-      "/usr/autodesk/maya2017"
   )
 endif(UNIX)
 
@@ -58,6 +57,7 @@ if(WIN32)
   find_path(MAYA_BASE_DIR include/maya/MFn.h
     PATH
       ENV MAYA_LOCATION
+        "C:/Program Files/Autodesk/Maya2020"
         "C:/Program Files/Autodesk/Maya2019"
         "C:/Program Files/Autodesk/Maya2018"
   )


### PR DESCRIPTION
- Adds cmake build support for Maya 2020 on all platforms
- Drops cmake build support for Maya 2018 on Linux only