### PR TITLE
Add Cast Shadows control for standard lights

### DIFF
--- a/scripts/appleseedMaya/AETemplates/__init__.py
+++ b/scripts/appleseedMaya/AETemplates/__init__.py
@@ -92,6 +92,7 @@ class AEappleseedNodeTemplate(pm.ui.AETemplate):
         elif self.thisNode.type() in {'pointLight', 'spotLight', 'directionalLight'}:
             self.beginLayout('appleseed', collapse=1)
             self.addControl('asCastIndirectLight', label='Cast Indirect Light')
+            self.addControl('asCastShadows', label='Cast Shadows')
             self.addSeparator()
             self.__buildVisibilitySection()
             self.endLayout()

--- a/src/appleseedmaya/exporters/lightexporter.cpp
+++ b/src/appleseedmaya/exporters/lightexporter.cpp
@@ -58,6 +58,13 @@ namespace
         AttributeUtils::get(node, "asCastIndirectLight", castIndirectLight);
         lightParams.insert_path("cast_indirect_light", castIndirectLight);
     }
+
+    void addCastShadowControls(const MObject& node, asr::ParamArray& lightParams)
+    {
+        bool castShadows = true;
+        AttributeUtils::get(node, "asCastShadows", castShadows);
+        lightParams.insert_path("cast_shadows", castShadows);
+    }
 };
 
 void LightExporter::registerExporter()
@@ -148,6 +155,7 @@ void LightExporter::createEntities(
         lightParams.insert("irradiance_multiplier", intensity);
 
         addIndirectLightControls(node(), lightParams);
+        addCastShadowControls(node(), lightParams);
     }
     else if (depNodeFn.typeName() == "pointLight")
     {
@@ -156,6 +164,7 @@ void LightExporter::createEntities(
         lightParams.insert("intensity_multiplier", intensity);
 
         addIndirectLightControls(node(), lightParams);
+        addCastShadowControls(node(), lightParams);
     }
     else if (depNodeFn.typeName() == "spotLight")
     {
@@ -173,6 +182,7 @@ void LightExporter::createEntities(
         lightParams.insert("outer_angle", outerAngle);
 
         addIndirectLightControls(node(), lightParams);
+        addCastShadowControls(node(), lightParams);
     }
     else
     {

--- a/src/appleseedmaya/extensionattributes.cpp
+++ b/src/appleseedmaya/extensionattributes.cpp
@@ -302,6 +302,17 @@ namespace
             AttributeUtils::makeInput(numAttrFn);
             modifier.addExtensionAttribute(nodeClass, attr);
 
+            attr = createNumericAttribute<bool>(
+                numAttrFn,
+                "asCastShadows",
+                "asCastShadows",
+                MFnNumericData::kBoolean,
+                true,
+                status);
+            numAttrFn.setKeyable(false);
+            AttributeUtils::makeInput(numAttrFn);
+            modifier.addExtensionAttribute(nodeClass, attr);
+
             addVisibilityExtensionAttributes(nodeClass, modifier);
             modifier.doIt();
         }


### PR DESCRIPTION
- Adds a checkbox to enable/disable casting of shadows for point/spot/directional lights
![Capture](https://user-images.githubusercontent.com/22252558/79696944-6fbc5c80-8288-11ea-9bf8-353653b10416.PNG)

 