### PR TITLE
Add render stamp scale factor

### DIFF
--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -1293,6 +1293,7 @@ class AppleseedRenderGlobalsOutputTab(AppleseedRenderGlobalsTab):
 
     def __renderStampChanged(self, value):
         self._uis["renderStampString"].setEnable(value)
+        self._uis["renderStampScaleFactor"].setEnable(value)
 
     def create(self):
         # Create default render globals node if needed.
@@ -1497,6 +1498,22 @@ class AppleseedRenderGlobalsOutputTab(AppleseedRenderGlobalsTab):
                                 enable=enableRenderStamp,
                                 annotation="Render stamp allows {lib-name|version|cpu-features|config|build-date|build-time}\n{render-time} and {peak-memory}."),
                             attrName="renderStampString")
+
+                        pm.separator(height=2)
+
+                        self._addFieldSliderControl(
+                                    label="Scale Factor",
+                                    sliderStep=0.1,
+                                    precision=2,
+                                    columnWidth=(3, 160),
+                                    columnAttach=(1, "right", 4),
+                                    enable=enableRenderStamp,
+                                    minValue=0.2,
+                                    maxValue=20.0,
+                                    fieldMinValue=0.1,
+                                    fieldMaxValue=30.0,
+                                    annotation="Render stamp scale factor.",
+                                    attrName="renderStampScaleFactor")
 
                         pm.separator(height=2)
 

--- a/scripts/appleseedMaya/renderGlobals.py
+++ b/scripts/appleseedMaya/renderGlobals.py
@@ -1508,7 +1508,7 @@ class AppleseedRenderGlobalsOutputTab(AppleseedRenderGlobalsTab):
                                     columnWidth=(3, 160),
                                     columnAttach=(1, "right", 4),
                                     enable=enableRenderStamp,
-                                    minValue=0.2,
+                                    minValue=0.1,
                                     maxValue=20.0,
                                     fieldMinValue=0.1,
                                     fieldMaxValue=30.0,

--- a/src/appleseedmaya/renderglobalsnode.cpp
+++ b/src/appleseedmaya/renderglobalsnode.cpp
@@ -697,7 +697,6 @@ MStatus RenderGlobalsNode::initialize()
     m_renderStampScaleFactor = numAttrFn.create("renderStampScaleFactor", "renderStampScaleFactor", MFnNumericData::kFloat, 1.0, &status);
     CHECKED_ADD_ATTRIBUTE(m_renderStampScaleFactor, "renderStampScaleFactor")
 
-
     // Log level.
     const short defaultLogLevel = static_cast<short>(asf::LogMessage::Info);
     m_logLevel = enumAttrFn.create("logLevel", "logLevel", defaultLogLevel, &status);
@@ -1213,7 +1212,7 @@ void RenderGlobalsNode::applyPostProcessStagesToFrame(const MObject& globals, as
         if (enabled)
         {
             asr::Frame* frame = project.get_frame();
-            auto stampParams = asr::ParamArray();
+            asr::ParamArray stampParams;
 
             float renderStampScaleFactor;
             if (AttributeUtils::get(MPlug(globals, m_renderStampScaleFactor), renderStampScaleFactor))
@@ -1224,10 +1223,10 @@ void RenderGlobalsNode::applyPostProcessStagesToFrame(const MObject& globals, as
             MString string;
             if (AttributeUtils::get(MPlug(globals, m_renderStampString), string))
             {
-                stampParams.insert("order", 0);
                 stampParams.insert("format_string", string.asChar());
             }
 
+            stampParams.insert("order", 0);
             frame->post_processing_stages().insert(
                 asr::RenderStampPostProcessingStageFactory().create(
                     "render_stamp", stampParams));

--- a/src/appleseedmaya/renderglobalsnode.h
+++ b/src/appleseedmaya/renderglobalsnode.h
@@ -206,7 +206,6 @@ class RenderGlobalsNode
     // Render stamp.
     static MObject      m_renderStamp;
     static MObject      m_renderStampScaleFactor;
-    static MObject      m_renderStampOrder;
     static MObject      m_renderStampString;
 
     // Logging.

--- a/src/appleseedmaya/renderglobalsnode.h
+++ b/src/appleseedmaya/renderglobalsnode.h
@@ -205,6 +205,8 @@ class RenderGlobalsNode
 
     // Render stamp.
     static MObject      m_renderStamp;
+    static MObject      m_renderStampScaleFactor;
+    static MObject      m_renderStampOrder;
     static MObject      m_renderStampString;
 
     // Logging.


### PR DESCRIPTION
Exposes the Render Stamp Scale Factor control in the Output Tab (similar to appleseed.studio).

![Capture](https://user-images.githubusercontent.com/22252558/101991058-dcbab180-3cb2-11eb-9228-0e90a26ef316.PNG)
